### PR TITLE
Fix bug 0x quantity flower

### DIFF
--- a/src/main/java/florizz/objects/Bouquet.java
+++ b/src/main/java/florizz/objects/Bouquet.java
@@ -78,7 +78,7 @@ public class Bouquet {
         // if flower already in bouquet
         if (doesFlowerExist(flowerName)) {
             Integer currentQuantity = getFlowerQuantity(flowerName);
-            Integer newQuantity = currentQuantity - quantity;
+            int newQuantity = currentQuantity - quantity;
             if (newQuantity < 0) {
                 System.out.println("Tried to remove more than the quantity available, quantity set to 0");
                 newQuantity = 0;

--- a/src/main/java/florizz/objects/Bouquet.java
+++ b/src/main/java/florizz/objects/Bouquet.java
@@ -80,14 +80,16 @@ public class Bouquet {
             Integer currentQuantity = getFlowerQuantity(flowerName);
             Integer newQuantity = currentQuantity - quantity;
             if (newQuantity < 0) {
-                System.out.println("Tried to remove more than quantity available, quantity set to 0");
+                System.out.println("Tried to remove more than the quantity available, quantity set to 0");
                 newQuantity = 0;
+            }
+            if (newQuantity == 0) {
+                flowerHashMap.remove(flowerName);
             }
             flowerHashMap.replace(flowerName, newQuantity);
             return true;
         }
         return false;
-
     }
 
     /**


### PR DESCRIPTION
When the quantity of the flowers is 0 after remove command is called, it should not be shown that there is 0x of a flower. This is because previously even though we have removed the full amount of a specific floewr, we did not remove the flower key from the hashmap. 